### PR TITLE
Added support for v16 filetypes

### DIFF
--- a/bvbabel/vmr.py
+++ b/bvbabel/vmr.py
@@ -50,8 +50,14 @@ def read_vmr(filename):
         # coregistration routines as well as for proper visualization.
 
         # Expected binary data: unsigned short int (2 bytes)
-        data, = struct.unpack('<H', f.read(2))
-        header["File version"] = data
+        if filename[-3:] == 'vmr':   # check file format used
+            data, = struct.unpack('<H', f.read(2))
+            header["File version"] = data
+            fformat = '<B'
+            fdepth = 1
+        else:   # asume 2 byte storage & no (post)header info for other filetypes
+            fformat = '<H'
+            fdepth = 2
         data, = struct.unpack('<H', f.read(2))
         header["DimX"] = data
         data, = struct.unpack('<H', f.read(2))
@@ -74,11 +80,11 @@ def read_vmr(filename):
         #   BV (Y top -> bottom) [axis 1 after np.reshape] = Z in Tal space
         #   BV (Z left -> right) [axis 0 after np.reshape] = X in Tal space
 
-        # Expected binary data: unsigned char (1 byte)
+        # Expected binary data: unsigned char or short int (1 or 2 byte(s), fformat dependent)
         data_img = np.zeros((header["DimZ"] * header["DimY"] * header["DimX"]),
-                            dtype="<B")
+                            dtype=fformat)
         for i in range(data_img.size):
-            data_img[i], = struct.unpack('<B', f.read(1))
+            data_img[i], = struct.unpack(fformat, f.read(fdepth))
         data_img = np.reshape(
             data_img, (header["DimZ"], header["DimY"], header["DimX"]))
 
@@ -103,6 +109,9 @@ def read_vmr(filename):
         # information further descries the data set, including the assumed
         # left-right convention, the reference space (e.g. Talairach after
         # normalization) and voxel resolution.
+
+        # Early return for headerless data (e.g. for v16 files)
+        if 'File version' not in header: return header, data_img
 
         if header["File version"] >= 3:
             # NOTE(Developer Guide 2.6): These four entries have been added in
@@ -260,8 +269,12 @@ def write_vmr(filename, header, data_img):
         # VMR Pre-Data Header
         # ---------------------------------------------------------------------
         # Expected binary data: unsigned short int (2 bytes)
-        data = header["File version"]
-        f.write(struct.pack('<H', data))
+        if filename[-3:] == 'vmr':   # check file format used
+            data = header["File version"]
+            f.write(struct.pack('<H', data))
+            fformat = '<B'
+        else:   # asume 2 byte storage & no (post)header info for other filetypes
+            fformat = '<H'
         data = header["DimX"]
         f.write(struct.pack('<H', data))
         data = header["DimY"]
@@ -276,10 +289,13 @@ def write_vmr(filename, header, data_img):
         data_img = data_img[::-1, ::-1, ::-1]  # Flip BV axes
         data_img = np.transpose(data_img, (0, 2, 1))  # BV to Tal
 
-        # Expected binary data: unsigned char (1 byte)
+        # Expected binary data: unsigned char or short int (1 or 2 byte(s), fformat dependent)
         data_img = data_img.flatten()
         for i in range(data_img.size):
-            f.write(struct.pack('<B', data_img[i]))
+            f.write(struct.pack(fformat, data_img[i]))
+
+        # Early return for (Post)headerless data (e.g. for v16 files)
+        if 'File version' not in header: return print("VMR saved.")
 
         # ---------------------------------------------------------------------
         # VMR Post-Data Header


### PR DESCRIPTION
Added support for file-types other then vmr (e.g. v16)

General mismatch and solutions include:
- v16 files are loaded and saved with minimim pre-data header and no post-data header information, vmr.py now reflects this approach
- v16 files rely on 2 bytes storage for intensity data, vmr.py now selects the bit depth based on filetypes (1 byte encoding for vmr, 2 bytes otherwise)

note: solution expect other file formats to be stored in 2 bytes, but for feature solutions it might be preferable to make this more flexible to accommodate custom file formats.