### PR TITLE
Changed method of loading data_img

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A lightweight Python library for reading & writing [BrainVoyager](https://www.br
 | FMR & STC   | Yes   | Yes   | No     |       No|
 | GLM         | No    | No    | No     |       No|
 | GTC         | Yes   | Yes   | No     |       No|
-| MTC         | No    | No    | No     |       No|
 | MSK         | Yes   | Yes   | No     |       No|
+| MTC         | No    | No    | No     |       No|
 | OBJ         | No    | Yes   | No     |       No|
 | POI         | No    | No    | No     |       No|
 | PRT         | No    | No    | No     |       No|

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight Python library for reading & writing [BrainVoyager](https://www.br
 | GLM         | No    | No    | No     |       No|
 | GTC         | Yes   | Yes   | No     |       No|
 | MTC         | No    | No    | No     |       No|
+| MSK         | Yes   | Yes   | No     |       No|
 | OBJ         | No    | Yes   | No     |       No|
 | POI         | No    | No    | No     |       No|
 | PRT         | No    | No    | No     |       No|

--- a/bvbabel/gtc.py
+++ b/bvbabel/gtc.py
@@ -46,9 +46,8 @@ def read_gtc(filename):
         #               DimT
         data_img = np.zeros(header["DimD"] * header["DimY"] * header["DimX"]
                             * header["DimT"], dtype=np.int32)
-        for i in range(data_img.size):
-            data, = struct.unpack('<i', f.read(4))
-            data_img[i] = data
+        data_img = np.fromfile(f, dtype='<i', count=data_img.size, sep="", 
+                               offset=0)
 
         # Rearrange data
         data_img = np.reshape(data_img, (header["DimD"], header["DimY"],

--- a/bvbabel/msk.py
+++ b/bvbabel/msk.py
@@ -1,0 +1,100 @@
+"""Read, write, create Brainvoyager MSK file format."""
+
+import struct
+import numpy as np
+
+# =============================================================================
+def read_msk(filename):
+    """Read Brainvoyager MSK file.
+    Parameters
+    ----------
+    filename : string
+        Path to file.
+    Returns
+    -------
+    header : dictionary
+        Pre-data header.
+    data : 3D numpy.array
+        Image data.
+    """
+    header = dict()
+    with open(filename, 'rb') as f:
+        
+        # Expected binary data: short int (2 bytes)
+        data, = struct.unpack('<h', f.read(2))
+        header["VTC resolution relative to VMR (1, 2, or 3)"] = data
+        
+        # Expected binary data: short int (2 bytes)
+        data, = struct.unpack('<h', f.read(2))
+        header["XStart"] = data
+        data, = struct.unpack('<h', f.read(2))
+        header["XEnd"] = data
+        data, = struct.unpack('<h', f.read(2))
+        header["YStart"] = data
+        data, = struct.unpack('<h', f.read(2))
+        header["YEnd"] = data
+        data, = struct.unpack('<h', f.read(2))
+        header["ZStart"] = data
+        data, = struct.unpack('<h', f.read(2))
+        header["ZEnd"] = data
+
+        # Prepare dimensions of VTC data array
+        VTC_resolution = header["VTC resolution relative to VMR (1, 2, or 3)"]
+        DimX = (header["XEnd"] - header["XStart"]) // VTC_resolution
+        DimY = (header["YEnd"] - header["YStart"]) // VTC_resolution
+        DimZ = (header["ZEnd"] - header["ZStart"]) // VTC_resolution
+        
+        # ---------------------------------------------------------------------
+        # Read MSK data
+        # ---------------------------------------------------------------------
+        
+        data_img = np.zeros(DimZ * DimY * DimX)
+        data_img = np.fromfile(f, dtype='<B', count=data_img.size, sep="", 
+                               offset=0)
+        data_img = np.reshape(data_img, (DimZ, DimY, DimX))
+        data_img = np.transpose(data_img, (0, 2, 1))  # BV to Tal
+        data_img = data_img[::-1, ::-1, ::-1]  # Flip BV axes
+
+    return header, data_img
+
+
+# =============================================================================
+def write_msk(filename, header, data_img):
+    """Protocol to write Brainvoyager MSK file.
+    Parameters
+    ----------
+    filename : string
+        Path to file.
+    header : dictionary
+        Pre-data header.
+    data_img : 3D numpy.array
+        Image data.
+    """
+    with open(filename, 'wb') as f:
+
+        # Expected binary data: short int (2 bytes)
+        data = header["VTC resolution relative to VMR (1, 2, or 3)"]
+        f.write(struct.pack('<h', data))
+
+        data = header["XStart"]
+        f.write(struct.pack('<h', data))
+        data = header["XEnd"]
+        f.write(struct.pack('<h', data))
+        data = header["YStart"]
+        f.write(struct.pack('<h', data))
+        data = header["YEnd"]
+        f.write(struct.pack('<h', data))
+        data = header["ZStart"]
+        f.write(struct.pack('<h', data))
+        data = header["ZEnd"]
+        f.write(struct.pack('<h', data))
+
+        # ---------------------------------------------------------------------
+        # Write MSK data
+        # ---------------------------------------------------------------------
+        data_img = data_img[::-1, ::-1, ::-1]  # Flip BV axes
+        data_img = np.transpose(data_img, (0, 2, 1))  # Tal to BV
+        data_img = np.reshape(data_img, data_img.size)
+
+        for i in range(data_img.size):
+            f.write(struct.pack('<B', int(data_img[i])))

--- a/bvbabel/vmp.py
+++ b/bvbabel/vmp.py
@@ -221,8 +221,8 @@ def read_vmp(filename):
         DimZ = (header["ZEnd"] - header["ZStart"]) // VMP_resolution
         DimT = header["NrOfSubMaps"]
         data_img = np.zeros(DimT * DimZ * DimY * DimX)
-        for i in range(data_img.size):
-            data_img[i], = struct.unpack('<f', f.read(4))
+        data_img = np.fromfile(f, dtype='<f', count=data_img.size, sep="", 
+                                   offset=0)
         data_img = np.reshape(data_img, (DimT, DimZ, DimY, DimX))
         data_img = np.transpose(data_img, (1, 3, 2, 0))  # BV to Tal
         data_img = data_img[::-1, ::-1, ::-1, :]  # Flip BV axes

--- a/bvbabel/vmr.py
+++ b/bvbabel/vmr.py
@@ -50,12 +50,8 @@ def read_vmr(filename):
         # coregistration routines as well as for proper visualization.
 
         # Expected binary data: unsigned short int (2 bytes)
-        if filename[-3:] == 'vmr':   # check file format used
-            data, = struct.unpack('<H', f.read(2))
-            header["File version"] = data
-            fformat = '<B'
-        else:   # asume 2 byte storage & no (post)header info for other filetypes
-            fformat = '<H'
+        data, = struct.unpack('<H', f.read(2))
+        header["File version"] = data
         data, = struct.unpack('<H', f.read(2))
         header["DimX"] = data
         data, = struct.unpack('<H', f.read(2))
@@ -78,10 +74,10 @@ def read_vmr(filename):
         #   BV (Y top -> bottom) [axis 1 after np.reshape] = Z in Tal space
         #   BV (Z left -> right) [axis 0 after np.reshape] = X in Tal space
 
-        # Expected binary data: unsigned char (1 or 2 byte(s), depending on fformat)
+        # Expected binary data: unsigned char (1 byte)
         data_img = np.zeros((header["DimZ"] * header["DimY"] * header["DimX"]),
-                            dtype=fformat)
-        data_img = np.fromfile(f, dtype=fformat, count=data_img.size, sep="", 
+                            dtype='<B')
+        data_img = np.fromfile(f, dtype='<B', count=data_img.size, sep="", 
                                offset=0)
         data_img = np.reshape(
             data_img, (header["DimZ"], header["DimY"], header["DimX"]))
@@ -107,9 +103,6 @@ def read_vmr(filename):
         # information further descries the data set, including the assumed
         # left-right convention, the reference space (e.g. Talairach after
         # normalization) and voxel resolution.
-
-        # Early return for headerless data (e.g. for v16 files)
-        if 'File version' not in header: return header, data_img
 
         if header["File version"] >= 3:
             # NOTE(Developer Guide 2.6): These four entries have been added in
@@ -267,12 +260,8 @@ def write_vmr(filename, header, data_img):
         # VMR Pre-Data Header
         # ---------------------------------------------------------------------
         # Expected binary data: unsigned short int (2 bytes)
-        if filename[-3:] == 'vmr':   # check file format used
-            data = header["File version"]
-            f.write(struct.pack('<H', data))
-            fformat = '<B'
-        else:   # asume 2 byte storage & no (post)header info for other filetypes
-            fformat = '<H'
+        data = header["File version"]
+        f.write(struct.pack('<H', data))
         data = header["DimX"]
         f.write(struct.pack('<H', data))
         data = header["DimY"]
@@ -287,13 +276,10 @@ def write_vmr(filename, header, data_img):
         data_img = data_img[::-1, ::-1, ::-1]  # Flip BV axes
         data_img = np.transpose(data_img, (0, 2, 1))  # BV to Tal
 
-        # Expected binary data: unsigned char (1 or 2 byte(s) depending on fformat)
+        # Expected binary data: unsigned char (1 or 2 byte)
         data_img = data_img.flatten()
         for i in range(data_img.size):
-            f.write(struct.pack(fformat, data_img[i]))
-
-        # Early return for (Post)headerless data (e.g. for v16 files)
-        if 'File version' not in header: return print("VMR saved.")
+            f.write(struct.pack('<B', data_img[i]))
 
         # ---------------------------------------------------------------------
         # VMR Post-Data Header

--- a/bvbabel/vtc.py
+++ b/bvbabel/vtc.py
@@ -104,11 +104,11 @@ def read_vtc(filename):
         data_img = np.zeros(DimZ * DimY * DimX * DimT)
 
         if header["Data type (1:short int, 2:float)"] == 1:
-            for i in range(data_img.size):
-                data_img[i], = struct.unpack('<h', f.read(2))
+            data_img = np.fromfile(f, dtype='<h', count=data_img.size, sep="", 
+                                   offset=0)
         elif header["Data type (1:short int, 2:float)"] == 2:
-            for i in range(data_img.size):
-                data_img[i], = struct.unpack('<f', f.read(4))
+            data_img = np.fromfile(f, dtype='<f', count=data_img.size, sep="", 
+                                   offset=0)
         else:
             raise("Unrecognized VTC data_img type.")
 


### PR DESCRIPTION
1. Pull Request (PR) includes a significant speedup for loading binary data; the method was changed from a sequential loop relying on struct.unpack to the highly efficient `np.fromfile`. Tests indicate no difference in output data and header variables.
2. PR includes a (re)implementation of support for v16 files for the `read_vmr` and `write_vmr` functions - now using the `np.fromfile` method.
3, PR also includes added support for BrainVoyager `.msk` files - now using the `np.fromfile` method.

While a slightly different implementation of 1 and 2 were PRed before, I deleted the old PR and resent this PR with both implementations now relying on the new sped-up `np.fromfile` method.