### PR TITLE
Update prt.py

### DIFF
--- a/bvbabel/prt.py
+++ b/bvbabel/prt.py
@@ -23,7 +23,7 @@ def read_prt(filename):
     """
     # Read non-empty lines of the input text file
     with open(filename, 'r') as f:
-        lines = [r for r in (line.strip() for line in f) if r]
+        lines = [r for r in (line.strip().replace('\t',' ') for line in f) if r]
 
     # PRT header
     header = dict()


### PR DESCRIPTION
If tabs instead of spaces have been used in the PRT file, the first value of the Color Definition was not properly read.