### PR TITLE
Changed readout from `<f` to `<i`

### DIFF
--- a/bvbabel/ssm.py
+++ b/bvbabel/ssm.py
@@ -41,6 +41,6 @@ def read_ssm(filename):
         # ---------------------------------------------------------------------
         data_ssm = np.zeros(header["Nr vertices 1"])
         for i in range(header["Nr vertices 1"]):
-            data_ssm[i], = struct.unpack('<f', f.read(4))
+            data_ssm[i], = struct.unpack('<i', f.read(4))
 
     return header, data_ssm


### PR DESCRIPTION
Changed binary readout character format from `f` to `i` to adhere to fix faulty readout. Returned `data_ssm` is now an array of integers. New readout data is consistent with Neuroelf and BrainVoyager.